### PR TITLE
Add test delay for MPDU sending

### DIFF
--- a/include/csp/drivers/sdr.h
+++ b/include/csp/drivers/sdr.h
@@ -11,6 +11,7 @@ typedef enum {
     SDR_UHF_4800_BAUD,
     SDR_UHF_9600_BAUD,
     SDR_UHF_19200_BAUD,
+    SDR_UHF_TEST_BAUD,
     SDR_UHF_END_BAUD,
 } sdr_uhf_baud_rate_t;
 

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -1115,6 +1115,7 @@ PyMODINIT_FUNC PyInit_libcsp_py3(void) {
     PyModule_AddIntConstant(m, "SDR_UHF_4800_BAUD", SDR_UHF_4800_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_9600_BAUD", SDR_UHF_9600_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_19200_BAUD", SDR_UHF_19200_BAUD);
+    PyModule_AddIntConstant(m, "SDR_UHF_TEST_BAUD", SDR_UHF_TEST_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_END_BAUD", SDR_UHF_END_BAUD);
 
     return m;

--- a/src/drivers/sdr/sdr_uart.c
+++ b/src/drivers/sdr/sdr_uart.c
@@ -47,7 +47,8 @@ static int sdr_uhf_baud_rate_delay[] = {
     [SDR_UHF_2400_BAUD] = 460,
     [SDR_UHF_4800_BAUD] = 240,
     [SDR_UHF_9600_BAUD] = 120,
-    [SDR_UHF_19200_BAUD] = 60
+    [SDR_UHF_19200_BAUD] = 60,
+    [SDR_UHF_TEST_BAUD] = 20,
 };
 
 int csp_sdr_tx(const csp_route_t *ifroute, csp_packet_t *packet) {


### PR DESCRIPTION
The delay needs to be approximately this long because the python code on the ground station can't keep up if the delay is 0