### PR TITLE
added ground station uhf baud rate symbol

### DIFF
--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -1138,7 +1138,7 @@ PyMODINIT_FUNC PyInit_libcsp_py3(void) {
     PyModule_AddIntConstant(m, "SDR_UHF_19200_BAUD", SDR_UHF_19200_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_TEST_BAUD", SDR_UHF_TEST_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_END_BAUD", SDR_UHF_END_BAUD);
-    PyModule_AddIntConstant(m, "SDR_UHF_GND_STATION_BAUD", SDR_UHF_GND_STATION_BAUD);
+    PyModule_AddIntConstant(m, "SDR_UHF_GNURADIO_BAUD", SDR_UHF_GNURADIO_BAUD);
 
     return m;
 }

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -1138,6 +1138,7 @@ PyMODINIT_FUNC PyInit_libcsp_py3(void) {
     PyModule_AddIntConstant(m, "SDR_UHF_19200_BAUD", SDR_UHF_19200_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_TEST_BAUD", SDR_UHF_TEST_BAUD);
     PyModule_AddIntConstant(m, "SDR_UHF_END_BAUD", SDR_UHF_END_BAUD);
+    PyModule_AddIntConstant(m, "SDR_UHF_GND_STATION_BAUD", SDR_UHF_GND_STATION_BAUD);
 
     return m;
 }


### PR DESCRIPTION
GS transmit doesn't need delays between packets, so this speeds up file upload significantly.

Must be merged alongside respectively named PRs in ex2_sdr and ex2_ground_station_software.